### PR TITLE
feat: fill in more Sensor discovery fields

### DIFF
--- a/crates/discovery/src/availability.rs
+++ b/crates/discovery/src/availability.rs
@@ -6,15 +6,36 @@ use crate::{
 use semval::{context::Context, Validate};
 use serde::{Deserialize, Serialize};
 
+/// When availability is configured, this controls the conditions needed to set the entity to available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum AvailabilityMode {
   /// If set to all, `payload_available` must be received on all configured availability topics before the entity is marked as online.
+  #[serde(rename = "all")]
   All,
 
   /// If set to any, `payload_available` must be received on at least one configured availability topic before the entity is marked as online.
+  #[serde(rename = "any")]
   Any,
 
   /// If set to latest, the last `payload_available` or `payload_not_available` received on any configured availability topic controls the availability.
+  ///
+  /// This is the default mode if not specified.
+  #[serde(rename = "latest")]
   Latest,
+}
+
+impl AvailabilityMode {
+  #[inline]
+  pub const fn is_default(&self) -> bool {
+    matches!(self, Self::Latest)
+  }
+}
+
+impl Default for AvailabilityMode {
+  #[inline]
+  fn default() -> Self {
+    Self::Latest
+  }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/discovery/src/availability.rs
+++ b/crates/discovery/src/availability.rs
@@ -1,6 +1,7 @@
 use crate::{
   exts::ValidateContextExt,
   payload::{Payload, PayloadInvalidity},
+  template::{Template, TemplateInvalidity},
   topic::{Topic, TopicInvalidity},
 };
 use semval::{context::Context, Validate};
@@ -55,6 +56,13 @@ pub struct Availability<'a> {
   /// The default (used if `None`) is `offline`.
   #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
   pub payload_not_available: Option<Payload<'a>>,
+
+  /// Defines a template to extract device’s availability from the topic.
+  ///
+  /// To determine the devices’s availability result of this template
+  /// will be compared to payload_available and payload_not_available.
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub value_template: Option<Template<'a>>,
 }
 
 impl<'a> Availability<'a> {
@@ -63,6 +71,7 @@ impl<'a> Availability<'a> {
       topic: topic.into(),
       payload_available: None,
       payload_not_available: None,
+      value_template: None,
     }
   }
 
@@ -75,6 +84,7 @@ impl<'a> Availability<'a> {
       topic: topic.into(),
       payload_available: Some(available_payload.into()),
       payload_not_available: Some(not_available_payload.into()),
+      value_template: None,
     }
   }
 }
@@ -84,6 +94,7 @@ pub enum AvailabilityDataInvalidity {
   Topic(TopicInvalidity),
   PayloadAvailable(PayloadInvalidity),
   PayloadNotAvailable(PayloadInvalidity),
+  ValueTemplate(TemplateInvalidity),
 }
 
 impl<'a> Validate for Availability<'a> {
@@ -99,6 +110,10 @@ impl<'a> Validate for Availability<'a> {
       .validate_with_opt(
         &self.payload_not_available,
         AvailabilityDataInvalidity::PayloadNotAvailable,
+      )
+      .validate_with_opt(
+        &self.value_template,
+        AvailabilityDataInvalidity::ValueTemplate,
       )
       .into()
   }
@@ -119,6 +134,7 @@ mod tests {
         topic: Topic(Cow::Borrowed("the/topic")),
         payload_available: None,
         payload_not_available: None,
+        value_template: None,
       },
       &[
         Token::Struct {
@@ -139,11 +155,12 @@ mod tests {
         topic: Topic(Cow::Borrowed("the/topic")),
         payload_available: Some(Payload(Cow::Borrowed("available"))),
         payload_not_available: Some(Payload(Cow::Borrowed("not_available"))),
+        value_template: Some(Template(Cow::Borrowed("{{value}}"))),
       },
       &[
         Token::Struct {
           name: name_of_type!(Availability),
-          len: 3,
+          len: 4,
         },
         Token::Str(name_of!(topic in Availability)),
         Token::Str("the/topic"),
@@ -153,6 +170,9 @@ mod tests {
         Token::Str(name_of!(payload_not_available in Availability)),
         Token::Some,
         Token::Str("not_available"),
+        Token::Str(name_of!(value_template in Availability)),
+        Token::Some,
+        Token::Str("{{value}}"),
         Token::StructEnd,
       ],
     )
@@ -171,6 +191,7 @@ mod tests {
       topic: Topic::from("topic"),
       payload_available: Some(Payload::from("")),
       payload_not_available: None,
+      value_template: None,
     }
     .validate()
     .expect_err("should be invalid")
@@ -191,6 +212,7 @@ mod tests {
       topic: Topic::from("topic"),
       payload_available: None,
       payload_not_available: Some(Payload::from("")),
+      value_template: None,
     }
     .validate()
     .expect_err("should be invalid")
@@ -211,6 +233,7 @@ mod tests {
       topic: Topic::from(""),
       payload_available: None,
       payload_not_available: None,
+      value_template: None,
     }
     .validate()
     .expect_err("should be invalid")

--- a/crates/discovery/src/entity/sensor.rs
+++ b/crates/discovery/src/entity/sensor.rs
@@ -15,7 +15,6 @@ use std::{borrow::Cow, num::NonZeroU32};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Sensor<'a> {
   /// A list of MQTT topics subscribed to receive availability (online/offline) updates.
-  /// Must not be used together with `availability_topic`.
   #[serde(borrow, default, skip_serializing_if = "<[Availability]>::is_empty")]
   pub availability: Cow<'a, [Availability<'a>]>,
 
@@ -23,16 +22,6 @@ pub struct Sensor<'a> {
   /// to set the entity to `available`.
   #[serde(default, skip_serializing_if = "AvailabilityMode::is_default")]
   pub availability_mode: AvailabilityMode,
-
-  /// Defines a template to extract device’s availability from the `availability_topic`.
-  /// To determine the devices’s availability result of this template will be compared
-  /// to `payload_available` and `payload_not_available`.
-  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
-  pub availability_template: Option<Template<'a>>,
-
-  /// The MQTT topic subscribed to receive availability (online/offline) updates.
-  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
-  pub availability_topic: Option<Topic<'a>>,
 
   /// Information about the device this sensor is a part of to tie it into the device registry.
   /// Only works through MQTT discovery and when `unique_id` is set.
@@ -101,16 +90,6 @@ pub struct Sensor<'a> {
   /// Used instead of `name` for automatic generation of `entity_id`.
   #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
   pub object_id: Option<Cow<'a, str>>,
-
-  /// The payload that represents the available state.
-  /// Defaults to `"online"`
-  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
-  pub payload_available: Option<Cow<'a, str>>,
-
-  /// The payload that represents the unavailable state.
-  /// Defaults to `"offline"`
-  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
-  pub payload_not_available: Option<Cow<'a, str>>,
 
   /// The maximum QoS level of the state topic.
   #[serde(default, skip_serializing_if = "MqttQoS::is_default")]

--- a/crates/discovery/src/entity/sensor.rs
+++ b/crates/discovery/src/entity/sensor.rs
@@ -1,4 +1,5 @@
 use crate::{
+  device::Device,
   device_class::DeviceClass, entity_category::EntityCategory, icon::Icon, name::Name, qos::MqttQoS,
   state_class::StateClass, template::Template, topic::Topic, unique_id::UniqueId,
 };
@@ -13,6 +14,12 @@ use std::{borrow::Cow, num::NonZeroU32};
 /// See: <https://www.home-assistant.io/integrations/sensor.mqtt/>
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Sensor<'a> {
+  /// Information about the device this sensor is a part of to tie it into the device registry.
+  /// Only works through MQTT discovery and when `unique_id` is set.
+  /// At least one of identifiers or connections must be present to identify the device.
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub device: Option<Device<'a>>,
+
   /// The [type/class][device_class] of the sensor to set
   /// the icon in the frontend.
   ///
@@ -70,6 +77,10 @@ pub struct Sensor<'a> {
   /// The name of the MQTT sensor. Default: `MQTT Sensor`.
   #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
   pub name: Option<Name<'a>>,
+
+  /// Used instead of `name` for automatic generation of `entity_id`.
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub object_id: Option<Cow<'a, str>>,
 
   /// The maximum QoS level of the state topic.
   #[serde(default, skip_serializing_if = "MqttQoS::is_default")]

--- a/crates/discovery/src/entity/sensor.rs
+++ b/crates/discovery/src/entity/sensor.rs
@@ -1,5 +1,5 @@
 use crate::{
-  device::Device,
+  availability::{Availability, AvailabilityMode}, device::Device,
   device_class::DeviceClass, entity_category::EntityCategory, icon::Icon, name::Name, qos::MqttQoS,
   state_class::StateClass, template::Template, topic::Topic, unique_id::UniqueId,
 };
@@ -14,6 +14,26 @@ use std::{borrow::Cow, num::NonZeroU32};
 /// See: <https://www.home-assistant.io/integrations/sensor.mqtt/>
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Sensor<'a> {
+  /// A list of MQTT topics subscribed to receive availability (online/offline) updates.
+  /// Must not be used together with `availability_topic`.
+  #[serde(borrow, default, skip_serializing_if = "<[Availability]>::is_empty")]
+  pub availability: Cow<'a, [Availability<'a>]>,
+
+  /// When `availability` is configured, this controls the conditions needed
+  /// to set the entity to `available`.
+  #[serde(default, skip_serializing_if = "AvailabilityMode::is_default")]
+  pub availability_mode: AvailabilityMode,
+
+  /// Defines a template to extract device’s availability from the `availability_topic`.
+  /// To determine the devices’s availability result of this template will be compared
+  /// to `payload_available` and `payload_not_available`.
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub availability_template: Option<Template<'a>>,
+
+  /// The MQTT topic subscribed to receive availability (online/offline) updates.
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub availability_topic: Option<Topic<'a>>,
+
   /// Information about the device this sensor is a part of to tie it into the device registry.
   /// Only works through MQTT discovery and when `unique_id` is set.
   /// At least one of identifiers or connections must be present to identify the device.
@@ -81,6 +101,16 @@ pub struct Sensor<'a> {
   /// Used instead of `name` for automatic generation of `entity_id`.
   #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
   pub object_id: Option<Cow<'a, str>>,
+
+  /// The payload that represents the available state.
+  /// Defaults to `"online"`
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub payload_available: Option<Cow<'a, str>>,
+
+  /// The payload that represents the unavailable state.
+  /// Defaults to `"offline"`
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub payload_not_available: Option<Cow<'a, str>>,
 
   /// The maximum QoS level of the state topic.
   #[serde(default, skip_serializing_if = "MqttQoS::is_default")]


### PR DESCRIPTION
adds missing fields to `entity::Sensor`