### PR TITLE
feat: Common `Entity` struct

### DIFF
--- a/crates/discovery/src/entity.rs
+++ b/crates/discovery/src/entity.rs
@@ -15,8 +15,10 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
 mod sensor;
+mod switch;
 
 pub use sensor::Sensor;
+pub use switch::Switch;
 
 /// Discoverable MQTT device configuration.
 ///

--- a/crates/discovery/src/entity.rs
+++ b/crates/discovery/src/entity.rs
@@ -1,3 +1,121 @@
+use crate::{
+  exts::ValidateContextExt,
+  availability::{Availability, AvailabilityMode, AvailabilityDataInvalidity},
+  device::{Device, DeviceInvalidity},
+  icon::{Icon, IconInvalidity},
+  name::{Name, NameInvalidity},
+  payload::PayloadInvalidity,
+  template::{Template, TemplateInvalidity},
+  topic::{Topic, TopicInvalidity},
+  entity_category::EntityCategory, qos::MqttQoS,
+  unique_id::{UniqueId, UniqueIdInvalidity},
+};
+use semval::{context::Context, Validate, ValidationResult};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
 mod sensor;
 
 pub use sensor::Sensor;
+
+/// Discoverable MQTT device configuration.
+///
+/// See: <https://www.home-assistant.io/docs/mqtt/discovery/>
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Entity<'a> {
+  /// A list of MQTT topics subscribed to receive availability (online/offline) updates.
+  #[serde(borrow, default, skip_serializing_if = "<[Availability]>::is_empty")]
+  pub availability: Cow<'a, [Availability<'a>]>,
+
+  /// When `availability` is configured, this controls the conditions needed
+  /// to set the entity to `available`.
+  #[serde(default, skip_serializing_if = "AvailabilityMode::is_default")]
+  pub availability_mode: AvailabilityMode,
+
+  /// Information about the device this entity is a part of to tie it into the device registry.
+  /// Only works through MQTT discovery and when `unique_id` is set.
+  /// At least one of identifiers or connections must be present to identify the device.
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub device: Option<Device<'a>>,
+
+  /// Flag which defines if the entity should be enabled when first added.
+  /// Defaults to `true`.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub enabled_by_default: Option<bool>,
+
+  /// The encoding of the payloads received and published messages. Set to "" to disable decoding of incoming payload.
+  /// Defaults to `"utf-8"`.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub encoding: Option<Cow<'a, str>>,
+
+  /// The [category] of the entity.
+  ///
+  /// [category]: https://developers.home-assistant.io/docs/core/entity#generic-properties
+  #[serde(default, skip_serializing_if = "EntityCategory::is_none")]
+  pub entity_category: EntityCategory,
+
+  /// [Icon][icon] for the entity.
+  ///
+  /// [icon]: https://www.home-assistant.io/docs/configuration/customizing-devices/#icon
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub icon: Option<Icon<'a>>,
+
+  /// Defines a [template][template] to extract the JSON dictionary from messages received
+  /// on the `json_attributes_topic`.
+  ///
+  /// [template]: https://www.home-assistant.io/docs/configuration/templating/#processing-incoming-data
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub json_attributes_template: Option<Template<'a>>,
+
+  /// The MQTT topic subscribed to receive a JSON dictionary payload and then set as entity
+  /// attributes.
+  ///
+  /// Implies `force_update` of the current state when a message is received on this topic.
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub json_attributes_topic: Option<Topic<'a>>,
+
+  /// The name of the MQTT entity.
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub name: Option<Name<'a>>,
+
+  /// Used instead of `name` for automatic generation of `entity_id`.
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub object_id: Option<Cow<'a, str>>,
+
+  /// The maximum QoS level of the state topic.
+  #[serde(default, skip_serializing_if = "MqttQoS::is_default")]
+  pub qos: MqttQoS,
+
+  /// An ID that uniquely identifies this entity. If two entities have the same unique ID,
+  /// Home Assistant will raise an exception.
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub unique_id: Option<UniqueId<'a>>,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum EntityInvalidity {
+  Availability(usize, AvailabilityDataInvalidity),
+  Device(DeviceInvalidity),
+  Icon(IconInvalidity),
+  Name(NameInvalidity),
+  Payload(PayloadInvalidity),
+  Template(TemplateInvalidity),
+  Topic(TopicInvalidity),
+  UniqueId(UniqueIdInvalidity),
+}
+
+impl<'a> Validate for Entity<'a> {
+  type Invalidity = EntityInvalidity;
+
+  fn validate(&self) -> ValidationResult<Self::Invalidity> {
+    Context::new()
+      .validate_iter(&*self.availability, EntityInvalidity::Availability)
+      .validate_with_opt(&self.device, EntityInvalidity::Device)
+      .validate_with_opt(&self.icon, EntityInvalidity::Icon)
+      .validate_with_opt(&self.json_attributes_template, EntityInvalidity::Template)
+      .validate_with_opt(&self.json_attributes_topic, EntityInvalidity::Topic)
+      .validate_with_opt(&self.name, EntityInvalidity::Name)
+      .validate_with_opt(&self.unique_id, EntityInvalidity::UniqueId)
+      .into()
+  }
+}

--- a/crates/discovery/src/entity/sensor.rs
+++ b/crates/discovery/src/entity/sensor.rs
@@ -1,7 +1,6 @@
 use crate::{
-  availability::{Availability, AvailabilityMode}, device::Device,
-  device_class::DeviceClass, entity_category::EntityCategory, icon::Icon, name::Name, qos::MqttQoS,
-  state_class::StateClass, template::Template, topic::Topic, unique_id::UniqueId,
+  entity::{Entity, EntityInvalidity},
+  device_class::DeviceClass, state_class::StateClass, template::Template, topic::Topic,
 };
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, num::NonZeroU32};
@@ -14,20 +13,8 @@ use std::{borrow::Cow, num::NonZeroU32};
 /// See: <https://www.home-assistant.io/integrations/sensor.mqtt/>
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Sensor<'a> {
-  /// A list of MQTT topics subscribed to receive availability (online/offline) updates.
-  #[serde(borrow, default, skip_serializing_if = "<[Availability]>::is_empty")]
-  pub availability: Cow<'a, [Availability<'a>]>,
-
-  /// When `availability` is configured, this controls the conditions needed
-  /// to set the entity to `available`.
-  #[serde(default, skip_serializing_if = "AvailabilityMode::is_default")]
-  pub availability_mode: AvailabilityMode,
-
-  /// Information about the device this sensor is a part of to tie it into the device registry.
-  /// Only works through MQTT discovery and when `unique_id` is set.
-  /// At least one of identifiers or connections must be present to identify the device.
-  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
-  pub device: Option<Device<'a>>,
+  #[serde(borrow, flatten)]
+  pub entity: Entity<'a>,
 
   /// The [type/class][device_class] of the sensor to set
   /// the icon in the frontend.
@@ -35,17 +22,6 @@ pub struct Sensor<'a> {
   /// [device_class]: https://www.home-assistant.io/integrations/sensor/#device-class
   #[serde(default, skip_serializing_if = "DeviceClass::is_none")]
   pub device_class: DeviceClass,
-
-  /// Flag which defines if the entity should be enabled when first added.
-  /// Defaults to `true`.
-  #[serde(default, skip_serializing_if = "Option::is_none")]
-  pub enabled_by_default: Option<bool>,
-
-  /// The [category] of the entity.
-  ///
-  /// [category]: https://developers.home-assistant.io/docs/core/entity#generic-properties
-  #[serde(default, skip_serializing_if = "EntityCategory::is_none")]
-  pub entity_category: EntityCategory,
 
   /// Defines the number of seconds after the value expires if it's not updated. After
   /// expiry, the sensor’s state becomes `unavailable`.
@@ -57,43 +33,12 @@ pub struct Sensor<'a> {
   #[serde(default, skip_serializing_if = "Option::is_none")]
   pub force_update: Option<bool>,
 
-  /// [Icon][icon] for the entity.
-  ///
-  /// [icon]: https://www.home-assistant.io/docs/configuration/customizing-devices/#icon
-  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
-  pub icon: Option<Icon<'a>>,
-
-  /// Defines a [template][template] to extract the JSON dictionary from messages received
-  /// on the `json_attributes_topic`.
-  ///
-  /// [template]: https://www.home-assistant.io/docs/configuration/templating/#processing-incoming-data
-  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
-  pub json_attributes_template: Option<Template<'a>>,
-
-  /// The MQTT topic subscribed to receive a JSON dictionary payload and then set as sensor
-  /// attributes. Implies `force_update` of the current sensor state when a message is
-  /// received on this topic.
-  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
-  pub json_attributes_topic: Option<Topic<'a>>,
-
   /// Defines a [template][template] to extract the last_reset. Available variables: `entity_id`.
   /// The `entity_id` can be used to reference the entity’s attributes.
   ///
   /// [template]: https://www.home-assistant.io/docs/configuration/templating/#processing-incoming-data
   #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
   pub last_reset_value_template: Option<Template<'a>>,
-
-  /// The name of the MQTT sensor. Default: `MQTT Sensor`.
-  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
-  pub name: Option<Name<'a>>,
-
-  /// Used instead of `name` for automatic generation of `entity_id`.
-  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
-  pub object_id: Option<Cow<'a, str>>,
-
-  /// The maximum QoS level of the state topic.
-  #[serde(default, skip_serializing_if = "MqttQoS::is_default")]
-  pub qos: MqttQoS,
 
   /// The [state_class][state_class] of the sensor.
   ///
@@ -104,11 +49,6 @@ pub struct Sensor<'a> {
   /// The MQTT topic subscribed to receive sensor values.
   #[serde(borrow)]
   pub state_topic: Topic<'a>,
-
-  /// An ID that uniquely identifies this sensor. If two sensors have the same unique ID,
-  /// Home Assistant will raise an exception.
-  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
-  pub unique_id: Option<UniqueId<'a>>,
 
   /// Defines the units of measurement of the sensor, if any.
   #[serde(borrow, default, skip_serializing_if = "Option::is_none")]

--- a/crates/discovery/src/entity/switch.rs
+++ b/crates/discovery/src/entity/switch.rs
@@ -1,0 +1,95 @@
+use crate::{
+  exts::ValidateContextExt,
+  entity::{Entity, EntityInvalidity},
+  device_class::DeviceClass, payload::Payload, template::Template, topic::Topic,
+};
+use semval::{context::Context, Validate, ValidationResult};
+use serde::{Deserialize, Serialize};
+
+/// The mqtt switch platform lets you control your MQTT enabled switches.
+///
+/// See: <https://www.home-assistant.io/integrations/switch.mqtt/>
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Switch<'a> {
+  #[serde(borrow, flatten)]
+  pub entity: Entity<'a>,
+
+  /// The MQTT topic to publish commands to change the switch state.
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub command_topic: Option<Topic<'a>>,
+
+  /// The [type/class][device_class] of the switch to set the icon in the frontend.
+  ///
+  /// [device_class]: https://www.home-assistant.io/integrations/switch/#device-class
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub device_class: Option<DeviceClass>,
+
+  /// Flag that defines if switch works in optimistic mode.
+  /// Defaults to `true` if no `state_topic` defined, else `false`.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub optimistic: Option<bool>,
+
+  /// The payload that represents `off` state. If specified, will be
+  /// used for both comparing to the value in the `state_topic` (see
+  /// `value_template` and `state_off` for details) and sending as
+  /// `off` command to the `command_topic`.
+  /// Defaults to `"OFF"`.
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub payload_off: Option<Payload<'a>>,
+
+  /// The payload that represents `on` state. If specified, will be
+  /// used for both comparing to the value in the `state_topic` (see
+  /// `value_template` and `state_on` for details) and sending as
+  /// `on` command to the `command_topic`.
+  /// Defaults to `"ON"`.
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub payload_on: Option<Payload<'a>>,
+
+  /// If the published message should have the retain flag on or not.
+  /// Defaults to `false`.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub retain: Option<bool>,
+
+  /// The payload that represents the `off` state. Used when value that
+  /// represents `off` state in the `state_topic` is different from value that
+  /// should be sent to the `command_topic` to turn the device `off`.
+  /// Defaults to `payload_off` if defined, else `"OFF"`.
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub state_off: Option<Payload<'a>>,
+
+  /// The payload that represents the `on` state. Used when value that
+  /// represents on state in the `state_topic` is different from value that
+  /// should be sent to the `command_topic` to turn the device `on`.
+  /// Defaults to `payload_on` if defined, else `"ON"`.
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub state_on: Option<Payload<'a>>,
+
+  /// The MQTT topic subscribed to receive state updates.
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub state_topic: Option<Topic<'a>>,
+
+  /// Defines a [template][template] to extract device’s state from the
+  /// `state_topic`. To determine the switches’s state result of this
+  /// template will be compared to `state_on` and `state_off`.
+  ///
+  /// [template]: https://www.home-assistant.io/docs/configuration/templating/#processing-incoming-data
+  #[serde(borrow, default, skip_serializing_if = "Option::is_none")]
+  pub value_template: Option<Template<'a>>,
+}
+
+impl<'a> Validate for Switch<'a> {
+  type Invalidity = EntityInvalidity;
+
+  fn validate(&self) -> ValidationResult<Self::Invalidity> {
+    Context::new()
+      .validate_with(&self.entity, |v| v)
+      .validate_with_opt(&self.command_topic, EntityInvalidity::Topic)
+      .validate_with_opt(&self.payload_on, EntityInvalidity::Payload)
+      .validate_with_opt(&self.payload_off, EntityInvalidity::Payload)
+      .validate_with_opt(&self.state_topic, EntityInvalidity::Topic)
+      .validate_with_opt(&self.state_on, EntityInvalidity::Payload)
+      .validate_with_opt(&self.state_off, EntityInvalidity::Payload)
+      .validate_with_opt(&self.value_template, EntityInvalidity::Template)
+      .into()
+  }
+}


### PR DESCRIPTION
This refactors the common fields of an entity into an `Entity` struct, then uses it to implement the `Switch` entity type. A follow-up to this might impl `Deref`/`DerefMut` (and maybe `AsRef`/`AsMut`) for the entity types (`Sensor` and `Switch`) to make the `.entity` field more "transparent".

I'd appreciate some feedback on whether a common base field like this makes sense.