### PR TITLE
fix: normalize device_class

### DIFF
--- a/crates/discovery/src/entity/button.rs
+++ b/crates/discovery/src/entity/button.rs
@@ -21,8 +21,8 @@ pub struct Button<'a> {
   /// The [type/class][device_class] of the button to set the icon in the frontend.
   ///
   /// [device_class]: https://www.home-assistant.io/integrations/button/#device-class
-  #[serde(default, skip_serializing_if = "Option::is_none")]
-  pub device_class: Option<DeviceClass>,
+  #[serde(default, skip_serializing_if = "DeviceClass::is_none")]
+  pub device_class: DeviceClass,
 
   /// The payload to send to trigger the button.
   /// Defaults to `"PRESS"`.

--- a/crates/discovery/src/entity/cover.rs
+++ b/crates/discovery/src/entity/cover.rs
@@ -23,8 +23,8 @@ pub struct Cover<'a> {
   /// Sets the [class of the device][device_class], changing the device state and icon that is displayed on the frontend.
   ///
   /// [device_class]: https://www.home-assistant.io/integrations/cover/#device-class
-  #[serde(default, skip_serializing_if = "Option::is_none")]
-  pub device_class: Option<DeviceClass>,
+  #[serde(default, skip_serializing_if = "DeviceClass::is_none")]
+  pub device_class: DeviceClass,
 
   /// Flag that defines if the cover works in optimistic mode.
   /// Defaults to `false` if a `state_topic` or `position_topic` is defined, else `true`.

--- a/crates/discovery/src/entity/switch.rs
+++ b/crates/discovery/src/entity/switch.rs
@@ -13,8 +13,8 @@ pub struct Switch<'a> {
   /// The [type/class][device_class] of the switch to set the icon in the frontend.
   ///
   /// [device_class]: https://www.home-assistant.io/integrations/switch/#device-class
-  #[serde(default, skip_serializing_if = "Option::is_none")]
-  pub device_class: Option<DeviceClass>,
+  #[serde(default, skip_serializing_if = "DeviceClass::is_none")]
+  pub device_class: DeviceClass,
 
   /// Flag that defines if switch works in optimistic mode.
   /// Defaults to `true` if no `state_topic` defined, else `false`.


### PR DESCRIPTION
Replace all uses of Option<DeviceClass> with just DeviceClass (as it contains it's own None variant).