### PR TITLE
fix(client): default-features = false for dependencies

### DIFF
--- a/crates/mqtt-client/Cargo.toml
+++ b/crates/mqtt-client/Cargo.toml
@@ -28,18 +28,18 @@ tracing = "0.1"
 tracing-error = "0.2"
 
 hass-dyn-error = { version = "0.0.0", path = "../dyn-error" }
-hass-mqtt-provider = { version = "0.0.0", path = "../mqtt-provider" }
-hass-mqtt-provider-paho = { version = "0.0.0", path = "../mqtt-provider-paho", default-features = true, optional = true }
+hass-mqtt-provider = { version = "0.0.0", path = "../mqtt-provider", default-features = false }
+hass-mqtt-provider-paho = { version = "0.0.0", path = "../mqtt-provider-paho", default-features = false, optional = true }
 hass-mqtt-types = { version = "0.0.0", path = "../mqtt-types", default-features = false }
 
 [build-dependencies]
 hass-provide-any-probe = { version = "0.0.0", path = "../../build/provide-any-probe" }
 
 [features]
-default = ["tls", "paho", "paho-bundled", "backtrace", "spantrace"]
+default = ["tls", "paho", "paho-bundled", "backtrace", "spantrace", "hass-mqtt-provider-paho?/default"]
 paho = ["hass-mqtt-provider-paho"]
 paho-bundled = ["hass-mqtt-provider-paho?/bundled"]
-tls = ["hass-mqtt-provider-paho?/ssl"]
+tls = ["hass-mqtt-provider/tls", "hass-mqtt-provider-paho?/ssl"]
 tls-bundled = ["tls", "hass-mqtt-provider-paho?/vendored-ssl"]
 backtrace = ["hass-mqtt-types/backtrace"]
 spantrace = ["hass-mqtt-types/spantrace"]


### PR DESCRIPTION
Otherwise, using `hass-mqtt-client` as a dependency enables a bunch of features you can't turn off!