### PR TITLE
fix: align light color attributes with JSON schema

### DIFF
--- a/crates/mqtt-proto/src/entity/light.rs
+++ b/crates/mqtt-proto/src/entity/light.rs
@@ -6,7 +6,7 @@ use hass_mqtt_macros::{entity_document, state_document};
 ///
 /// See: <https://www.home-assistant.io/integrations/light.mqtt/#json-schema>
 #[entity_document]
-#[entity(extend_json(schema = "json"))]
+#[entity(extend_json(schema = "json", platform = "light"))]
 #[entity(validate(ColorModeWithoutSupportedColorModes))]
 pub struct Light<'a> {
 	/// Flag that defines if the light supports brightness.
@@ -348,57 +348,57 @@ impl<'a> LightState<'a> {
 pub struct LightColorState {
 	#[cfg_attr(
 		any(feature = "ser", feature = "de"),
-		serde(default, skip_serializing_if = "Option::is_none")
+		serde(default, skip_serializing_if = "Option::is_none", rename = "r")
 	)]
-	red: Option<u8>,
+	pub red: Option<u8>,
+
+	#[cfg_attr(
+		any(feature = "ser", feature = "de"),
+		serde(default, skip_serializing_if = "Option::is_none", rename = "g")
+	)]
+	pub green: Option<u8>,
+
+	#[cfg_attr(
+		any(feature = "ser", feature = "de"),
+		serde(default, skip_serializing_if = "Option::is_none", rename = "b")
+	)]
+	pub blue: Option<u8>,
 
 	#[cfg_attr(
 		any(feature = "ser", feature = "de"),
 		serde(default, skip_serializing_if = "Option::is_none")
 	)]
-	green: Option<u8>,
+	pub cold_white: Option<u8>,
 
 	#[cfg_attr(
 		any(feature = "ser", feature = "de"),
 		serde(default, skip_serializing_if = "Option::is_none")
 	)]
-	blue: Option<u8>,
+	pub white: Option<u8>,
 
 	#[cfg_attr(
 		any(feature = "ser", feature = "de"),
 		serde(default, skip_serializing_if = "Option::is_none")
 	)]
-	cold_white: Option<u8>,
+	pub x: Option<f32>,
 
 	#[cfg_attr(
 		any(feature = "ser", feature = "de"),
 		serde(default, skip_serializing_if = "Option::is_none")
 	)]
-	white: Option<u8>,
+	pub y: Option<f32>,
 
 	#[cfg_attr(
 		any(feature = "ser", feature = "de"),
-		serde(default, skip_serializing_if = "Option::is_none")
+		serde(default, skip_serializing_if = "Option::is_none", rename = "h")
 	)]
-	x: Option<f32>,
+	pub hue: Option<f32>,
 
 	#[cfg_attr(
 		any(feature = "ser", feature = "de"),
-		serde(default, skip_serializing_if = "Option::is_none")
+		serde(default, skip_serializing_if = "Option::is_none", rename = "s")
 	)]
-	y: Option<f32>,
-
-	#[cfg_attr(
-		any(feature = "ser", feature = "de"),
-		serde(default, skip_serializing_if = "Option::is_none")
-	)]
-	hue: Option<f32>,
-
-	#[cfg_attr(
-		any(feature = "ser", feature = "de"),
-		serde(default, skip_serializing_if = "Option::is_none")
-	)]
-	saturation: Option<f32>,
+	pub saturation: Option<f32>,
 }
 
 impl LightColorState {


### PR DESCRIPTION
The discovery document for light entities [declares][1] [JSON Schema][2]
payloads.
In this format, color attribute names are abbreviated. Consequently,
without renaming the light entity color attributes, incoming
messages are not parsed correctly.

As an example, here's a command payload, issued by HomeAssistant,
requesting that color be set to the specified hue and saturation values:

```json
{"state":"ON","color":{"h":9.123,"s":67.059}}
```

Per the current definition of `LightColorState` we expect `hue` and
`saturation`, but we get `h` and `s`.

**Changes**:

- Rename all `LightColorState` properties.
- Ensure `platform` is strictly `"light"` for light entities.
- Make `LightColorState`'s properties public, so that they are accessible.

[1]: https://github.com/YoloDev/hass-rs/blob/9b332ebff17a5c24fa1c5a972d160b29de90fd4d/crates/mqtt-proto/src/entity/light.rs#L9
[2]: https://www.home-assistant.io/integrations/light.mqtt/#json-schema
